### PR TITLE
Force ember-inflector v2.2.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "ember-inflector": "2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.2.0-beta.6",
     "ember-cli-app-version": "^1.0.0",


### PR DESCRIPTION
as a workaround for the bug introduced in April.

See the following issues:
  - https://github.com/emberjs/ember-inflector/issues/145
  - https://github.com/udacity/FEF-Quiz-Ember-Nested-Routes/issues/1